### PR TITLE
Bump the jade version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
 		"Vladislav Botvin <darkvlados@me.com> (https://github.com/darrrk)"
 	],
 	"bugs": {
-		"url": "https://github.com/bevry/docpad-extras/issues"
+		"url": "https://github.com/docpad/docpad-plugin-jade/issues"
 	},
 	"repository" : {
 		"type": "git",
-		"url": "http://github.com/bevry/docpad-extras.git"
+		"url": "git://github.com/docpad/docpad-plugin-jade.git"
 	},
 	"engines" : {
 		"node": ">=0.4.0",


### PR DESCRIPTION
This version of jade (0.28.x) provides the ability to include markdown files within a jade file like so:

``` Jade
include ../markdown/fileToEmbed.md
```

I also changed the repo URLs in the package.json to the correct URLs.
