### PR TITLE
Updated jade dependency from ~1.9.2 to ~1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "docpad": "6"
   },
   "dependencies": {
-    "jade": "~1.9.2"
+    "jade": "~1.11.0"
   },
   "devDependencies": {
     "coffee-script": "^1.9.1",


### PR DESCRIPTION
Jade added `jstransformers` support in v1.10.0 which allows easy creation of custom filters. 